### PR TITLE
Add mood history test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# health
+# Health
+
+Simple health tracker interface.
+
+## Running Tests
+
+Install Node.js (v18 or higher) and run:
+
+```
+npm test
+```
+
+This uses Node's built-in test runner to execute tests in the `test` directory.

--- a/mood.js
+++ b/mood.js
@@ -1,0 +1,19 @@
+const moodHistory = [];
+
+function logMood(moodValue, date = new Date()) {
+  const mood = parseInt(moodValue, 10);
+  const dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+
+  const existingIndex = moodHistory.findIndex(h => h.date === dateStr);
+  if (existingIndex !== -1) {
+    moodHistory[existingIndex].value = mood;
+  } else {
+    moodHistory.push({ date: dateStr, value: mood });
+  }
+
+  if (moodHistory.length > 7) {
+    moodHistory.shift();
+  }
+}
+
+module.exports = { logMood, moodHistory };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "health",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/mood.test.js
+++ b/test/mood.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('assert');
+const { logMood, moodHistory } = require('../mood');
+
+test('keeps only the last seven mood entries', () => {
+  moodHistory.length = 0; // reset
+  for (let i = 0; i < 8; i++) {
+    const date = new Date(2024, 0, i + 1); // Jan 1..8
+    logMood(i, date);
+  }
+  assert.strictEqual(moodHistory.length, 7);
+});


### PR DESCRIPTION
## Summary
- set up a simple Node-based test harness
- export `logMood` and `moodHistory`
- test that `logMood` keeps only 7 entries
- document how to run the tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889a57fa0e8832e91c8981d5e1116f1