### PR TITLE
Implement rule engine and report page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+/dist/
+frontend/node_modules
+frontend/dist
+frontend/package-lock.json

--- a/frontend/lib/ruleEngine.js
+++ b/frontend/lib/ruleEngine.js
@@ -1,0 +1,25 @@
+import rules from './rules.json';
+
+export function evaluateRules(userData) {
+  const context = { ...userData, modules: [], top_actions: [] };
+  const sorted = [...rules].sort((a, b) => (b.priority || 0) - (a.priority || 0));
+  for (const rule of sorted) {
+    const when = rule.when || {};
+    const match = Object.entries(when).every(([k, v]) => userData[k] === v);
+    if (match) {
+      const then = rule.then || {};
+      if (then.set) {
+        Object.entries(then.set).forEach(([k, v]) => {
+          context[k] = v;
+        });
+      }
+      if (then.add_modules) {
+        context.modules.push(...then.add_modules);
+      }
+      if (then.add_top_actions) {
+        context.top_actions.push(...then.add_top_actions);
+      }
+    }
+  }
+  return context;
+}

--- a/frontend/lib/rules.json
+++ b/frontend/lib/rules.json
@@ -1,0 +1,21 @@
+[
+  {
+    "priority": 10,
+    "when": { "exercise": "none" },
+    "then": {
+      "add_top_actions": [
+        { "title": "Start Small Workouts", "description": "Begin with 10 minute walks each day." }
+      ],
+      "set": { "level": "L1" }
+    }
+  },
+  {
+    "priority": 5,
+    "when": { "sleep": "poor" },
+    "then": {
+      "add_top_actions": [
+        { "title": "Improve Sleep Hygiene", "description": "Establish a regular bedtime routine." }
+      ]
+    }
+  }
+]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Landing from './pages/Landing';
 import Questionnaire from './pages/Questionnaire';
+import Report from './pages/Report';
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/questionnaire" element={<Questionnaire />} />
+        <Route path="/report" element={<Report />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Questionnaire.jsx
+++ b/frontend/src/pages/Questionnaire.jsx
@@ -1,7 +1,56 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { evaluateRules } from '../../lib/ruleEngine';
+
+const questions = [
+  {
+    key: 'exercise',
+    question: 'How often do you exercise?',
+    options: ['regularly', 'sometimes', 'none'],
+  },
+  {
+    key: 'sleep',
+    question: 'How do you rate your sleep?',
+    options: ['good', 'ok', 'poor'],
+  },
+  {
+    key: 'condition',
+    question: 'Do you have any chronic conditions?',
+    options: ['yes', 'no'],
+  },
+];
+
 export default function Questionnaire() {
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState({});
+  const navigate = useNavigate();
+
+  const current = questions[step];
+  const progress = `${step + 1} / ${questions.length}`;
+
+  const handleAnswer = (option) => {
+    const newData = { ...answers, [current.key]: option };
+    setAnswers(newData);
+    if (step < questions.length - 1) {
+      setStep(step + 1);
+    } else {
+      const context = evaluateRules(newData);
+      localStorage.setItem('reportContext', JSON.stringify(context));
+      navigate(`/report?level=${context.level || 'L1'}`);
+    }
+  };
+
   return (
-    <div className="min-h-screen flex items-center justify-center text-center">
-      <h1 className="text-2xl font-semibold">Questionnaire Coming Soon</h1>
+    <div className="min-h-screen flex flex-col items-center justify-center text-center gap-6">
+      <h2 className="text-2xl font-semibold mb-1">{current.question}</h2>
+      <div className="text-sm text-text-muted">Question {progress}</div>
+      <div className="flex flex-col gap-4">
+        {current.options.map((opt) => (
+          <button key={opt} className="btn" onClick={() => handleAnswer(opt)}>
+            {opt}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Report.jsx
+++ b/frontend/src/pages/Report.jsx
@@ -1,0 +1,41 @@
+import { Link, useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+export default function Report() {
+  const [context, setContext] = useState({ top_actions: [] });
+  const location = useLocation();
+  const level = new URLSearchParams(location.search).get('level');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('reportContext');
+    if (saved) {
+      setContext(JSON.parse(saved));
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen p-6 flex flex-col items-center gap-6">
+      <h1 className="text-3xl font-bold">Thank you!</h1>
+      {level && (
+        <p className="text-text-muted">Your recommended level: {level}</p>
+      )}
+      <p className="text-text-muted">Here are your top actions:</p>
+      <div className="grid gap-4 w-full max-w-xl">
+        {context.top_actions.slice(0, 5).map((a, idx) => (
+          <div key={idx} className="bg-white p-4 rounded shadow">
+            <h3 className="font-semibold text-lg mb-1">{a.title}</h3>
+            <p className="text-text-muted text-sm">{a.description}</p>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-4 mt-6">
+        <button className="btn" onClick={() => window.print()}>
+          Download PDF
+        </button>
+        <Link to="/questionnaire" className="btn bg-accent hover:bg-emerald-600">
+          Go back to Questionnaire
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add rule evaluation logic and sample rules
- upgrade Questionnaire to evaluate rules after last question
- store rule context and create new report page
- hook up report route and ignore build artifacts
- show questionnaire progress and display level on report page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688acba18c24832e9d0f937049883df6