### PR TITLE
Implement questionnaire wizard and extended rules

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Landing from './pages/Landing';
 import Questionnaire from './pages/Questionnaire';
+import Report from './pages/Report';
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/questionnaire" element={<Questionnaire />} />
+        <Route path="/report" element={<Report />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Questionnaire.jsx
+++ b/frontend/src/pages/Questionnaire.jsx
@@ -1,103 +1,301 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import questions from '../../rules.json';
 
-function shouldShow(question, answers) {
-  if (!question.show_if) return true;
-  return answers[question.show_if.id] === question.show_if.value;
+function evaluateShowIf(exp, answers) {
+  if (!exp) return true;
+  // Q23 includes 'htn'
+  const includeMatch = exp.match(/(Q\d+) includes '([^']+)'/);
+  if (includeMatch) {
+    const val = answers[includeMatch[1]];
+    return Array.isArray(val) ? val.includes(includeMatch[2]) : false;
+  }
+  const inMatch = exp.match(/(Q\d+) in \[([^\]]+)\]/);
+  if (inMatch) {
+    const val = answers[inMatch[1]];
+    const opts = inMatch[2].split(',').map(s => s.trim().replace(/^'|'$/g,''));
+    return opts.includes(val);
+  }
+  const eqMatch = exp.match(/(Q\d+) == (.+)/);
+  if (eqMatch) {
+    const val = answers[eqMatch[1]];
+    const rhs = eqMatch[2].trim();
+    if (rhs === 'true') return val === true;
+    if (rhs === 'false') return val === false;
+    return String(val) === rhs.replace(/^'|'$/g,'');
+  }
+  return true;
+}
+
+function setNested(obj, path, value) {
+  const parts = path.split('.');
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (!cur[parts[i]]) cur[parts[i]] = {};
+    cur = cur[parts[i]];
+  }
+  cur[parts[parts.length - 1]] = value;
 }
 
 export default function Questionnaire() {
+  const navigate = useNavigate();
+  const [answers, setAnswers] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('answers')) || {};
+    } catch {
+      return {};
+    }
+  });
   const [step, setStep] = useState(0);
-  const [answers, setAnswers] = useState({});
 
-  const visibleQuestions = useMemo(
-    () => questions.filter(q => shouldShow(q, answers)),
-    [answers]
-  );
+  useEffect(() => {
+    localStorage.setItem('answers', JSON.stringify(answers));
+  }, [answers]);
 
-  const current = visibleQuestions[step];
+  const sections = useMemo(() => {
+    const groups = [];
+    questions.forEach(q => {
+      let g = groups.find(g => g.name === q.section);
+      if (!g) {
+        g = { name: q.section, questions: [] };
+        groups.push(g);
+      }
+      g.questions.push(q);
+    });
+    return groups;
+  }, []);
 
-  const handleChange = value => {
-    setAnswers(prev => ({ ...prev, [current.id]: value }));
+  const visibleQuestions = section =>
+    section.questions.filter(q => evaluateShowIf(q.show_if, answers));
+
+  const isSectionValid = section => {
+    const qs = visibleQuestions(section);
+    return qs.every(q => {
+      if (!q.required) return true;
+      const val = answers[q.id];
+      if (typeof val === 'undefined' || val === '' || (Array.isArray(val) && val.length === 0))
+        return false;
+      return true;
+    });
+  };
+
+  const currentSection = sections[step];
+  const total = sections.length;
+  if (!currentSection) return null;
+
+  const handleAnswer = (id, value) => {
+    setAnswers(prev => ({ ...prev, [id]: value }));
   };
 
   const next = () => {
-    if (typeof answers[current.id] === 'undefined' || answers[current.id] === '') return;
-    setStep(prev => prev + 1);
+    if (!isSectionValid(currentSection)) return;
+    if (step === total - 1) {
+      const data = {};
+      questions.forEach(q => {
+        const ans = answers[q.id];
+        if (typeof ans === 'undefined') return;
+        if (Array.isArray(q.maps_to)) {
+          q.maps_to.forEach((p, idx) => setNested(data, p, ans[idx]));
+        } else {
+          setNested(data, q.maps_to, ans);
+        }
+      });
+      localStorage.setItem('userData', JSON.stringify(data));
+      navigate('/report?level=L1');
+    } else {
+      setStep(s => s + 1);
+    }
   };
 
-  const back = () => setStep(prev => (prev > 0 ? prev - 1 : 0));
+  const back = () => setStep(s => (s > 0 ? s - 1 : 0));
 
-  if (!current) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center">
-        <h1 className="text-2xl font-semibold mb-2">Thanks! Your answers were submitted.</h1>
-      </div>
-    );
-  }
-
-  let input = null;
-  const value = answers[current.id] ?? '';
-
-  if (current.type === 'yesno') {
-    input = (
-      <div className="space-x-4">
-        <button
-          onClick={() => handleChange('yes')}
-          className={`btn ${value === 'yes' ? 'bg-primary text-white' : 'bg-gray-200'}`}
-        >
-          Yes
-        </button>
-        <button
-          onClick={() => handleChange('no')}
-          className={`btn ${value === 'no' ? 'bg-primary text-white' : 'bg-gray-200'}`}
-        >
-          No
-        </button>
-      </div>
-    );
-  } else if (current.type === 'choice') {
-    input = (
-      <select
-        className="mt-4 p-2 border rounded"
-        value={value}
-        onChange={e => handleChange(e.target.value)}
-      >
-        <option value="" disabled>
-          Select an option
-        </option>
-        {current.options.map(opt => (
-          <option key={opt} value={opt}>
-            {opt}
-          </option>
-        ))}
-      </select>
-    );
-  } else if (current.type === 'number') {
-    input = (
-      <input
-        type="number"
-        className="mt-4 p-2 border rounded w-32 text-center"
-        value={value}
-        onChange={e => handleChange(e.target.value)}
-      />
-    );
-  }
+  const renderInput = (q) => {
+    const val = answers[q.id];
+    switch (q.input_type) {
+      case 'yes_no':
+        return (
+          <div className="space-x-2 mt-2">
+            {['yes', 'no'].map(opt => (
+              <button
+                key={opt}
+                onClick={() => handleAnswer(q.id, opt === 'yes')}
+                className={`btn ${val === (opt === 'yes') ? 'bg-accent text-white' : 'bg-gray-200'}`}
+              >
+                {opt === 'yes' ? 'Yes' : 'No'}
+              </button>
+            ))}
+          </div>
+        );
+      case 'single_choice': {
+        const opts = q.options_dynamic_from ? answers[q.options_dynamic_from] || [] : q.options;
+        return (
+          <div className="flex flex-wrap gap-2 mt-2">
+            {opts.map(opt => (
+              <button
+                key={opt}
+                onClick={() => handleAnswer(q.id, opt)}
+                className={`btn ${val === opt ? 'bg-accent text-white' : 'bg-gray-200'}`}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+        );
+      }
+      case 'multi_choice':
+        return (
+          <div className="flex flex-wrap gap-2 mt-2">
+            {q.options.map(opt => {
+              const selected = Array.isArray(val) && val.includes(opt);
+              const disabled = q.max_choices && !selected && Array.isArray(val) && val.length >= q.max_choices;
+              return (
+                <button
+                  key={opt}
+                  disabled={disabled}
+                  onClick={() => {
+                    let newVal = Array.isArray(val) ? [...val] : [];
+                    if (selected) newVal = newVal.filter(o => o !== opt);
+                    else newVal.push(opt);
+                    handleAnswer(q.id, newVal);
+                  }}
+                  className={`btn ${selected ? 'bg-accent text-white' : 'bg-gray-200'} ${disabled ? 'opacity-50' : ''}`}
+                >
+                  {opt}
+                </button>
+              );
+            })}
+          </div>
+        );
+      case 'number_cm':
+      case 'number_kg':
+      case 'number_hours':
+      case 'number':
+        return (
+          <input
+            type="number"
+            min={q.min}
+            max={q.max}
+            step={q.step || 'any'}
+            placeholder={q.placeholder}
+            className="mt-2 p-2 border rounded w-40 text-center"
+            value={val || ''}
+            onChange={e => handleAnswer(q.id, e.target.value ? Number(e.target.value) : '')}
+          />
+        );
+      case 'number_pair': {
+        const [sbp, dbp] = Array.isArray(val) ? val : ['', ''];
+        return (
+          <div className="flex gap-2 mt-2">
+            <input
+              type="number"
+              className="p-2 border rounded w-20 text-center"
+              placeholder="SBP"
+              value={sbp}
+              onChange={e => handleAnswer(q.id, [e.target.value ? Number(e.target.value) : '', dbp])}
+            />
+            <input
+              type="number"
+              className="p-2 border rounded w-20 text-center"
+              placeholder="DBP"
+              value={dbp}
+              onChange={e => handleAnswer(q.id, [sbp, e.target.value ? Number(e.target.value) : ''])}
+            />
+          </div>
+        );
+      }
+      case 'date_or_number': {
+        const [dob, age] = Array.isArray(val) ? val : ['', ''];
+        return (
+          <div className="flex gap-2 mt-2">
+            <input
+              type="date"
+              className="p-2 border rounded"
+              value={dob}
+              onChange={e => handleAnswer(q.id, [e.target.value, age])}
+            />
+            <input
+              type="number"
+              placeholder="Age"
+              className="p-2 border rounded w-24"
+              value={age}
+              onChange={e => handleAnswer(q.id, [dob, e.target.value ? Number(e.target.value) : ''])}
+            />
+          </div>
+        );
+      }
+      case 'scale_0_10':
+        return (
+          <div className="mt-4 flex flex-col items-center">
+            <input
+              type="range"
+              min="0"
+              max="10"
+              value={val || 0}
+              onChange={e => handleAnswer(q.id, Number(e.target.value))}
+              className="w-64"
+            />
+            <div className="mt-2">{val ?? 0}</div>
+          </div>
+        );
+      case 'phq2_scale':
+      case 'gad2_scale':
+        const opts4 = ['Not at all','Several days','More than half the days','Nearly every day'];
+        return (
+          <div className="flex flex-col mt-2 gap-2">
+            {opts4.map((opt,i) => (
+              <button
+                key={i}
+                onClick={() => handleAnswer(q.id, i)}
+                className={`btn text-left ${val===i ? 'bg-accent text-white' : 'bg-gray-200'}`}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+        );
+      case 'text':
+        return (
+          <textarea
+            rows="3"
+            className="mt-2 p-2 border rounded w-full"
+            placeholder={q.placeholder}
+            value={val || ''}
+            onChange={e => handleAnswer(q.id, e.target.value)}
+          />
+        );
+      default:
+        return null;
+    }
+  };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center space-y-6">
-      <div className="text-sm text-text-muted">Question {step + 1} of {visibleQuestions.length}</div>
-      <h1 className="text-xl font-semibold">{current.text}</h1>
-      {input}
-      <div className="space-x-4 mt-4">
-        {step > 0 && (
-          <button onClick={back} className="btn bg-gray-200">
-            Back
+    <div className="min-h-screen flex flex-col items-center py-8 px-4 space-y-6">
+      <h1 className="text-3xl font-bold">MyDailyAgency Health</h1>
+      <div className="w-full max-w-2xl">
+        <div className="mb-4 text-sm text-text-muted">Section {step + 1} of {total}</div>
+        <div className="w-full bg-gray-200 h-2 rounded mb-6">
+          <div className="bg-primary h-2 rounded" style={{width:`${((step)/total)*100}%`}} />
+        </div>
+        <h2 className="text-xl font-semibold mb-4">{currentSection.name}</h2>
+        {visibleQuestions(currentSection).map(q => (
+          <div key={q.id} className="mb-6">
+            <div className="font-medium">{q.text}</div>
+            {q.help_text && <div className="text-sm text-text-muted">{q.help_text}</div>}
+            {renderInput(q)}
+          </div>
+        ))}
+        <div className="flex justify-between mt-4">
+          {step > 0 ? (
+            <button onClick={back} className="btn bg-gray-200">Back</button>
+          ) : <span />}
+          <button
+            onClick={next}
+            className={`btn ${isSectionValid(currentSection) ? 'bg-primary text-white' : 'bg-gray-300 cursor-not-allowed'}`}
+            disabled={!isSectionValid(currentSection)}
+          >
+            {step === total - 1 ? 'Submit' : 'Next'}
           </button>
-        )}
-        <button onClick={next} className="btn bg-primary text-white">
-          {step === visibleQuestions.length - 1 ? 'Submit' : 'Next'}
-        </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Report.jsx
+++ b/frontend/src/pages/Report.jsx
@@ -1,0 +1,13 @@
+import { useLocation } from 'react-router-dom';
+
+export default function Report() {
+  const { search } = useLocation();
+  const level = new URLSearchParams(search).get('level');
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center text-center p-4 space-y-4">
+      <h1 className="text-3xl font-bold">MyDailyAgency Health</h1>
+      <p className="text-lg">Report placeholder - level {level}</p>
+    </div>
+  );
+}

--- a/rules.json
+++ b/rules.json
@@ -1,30 +1,47 @@
 [
-  {
-    "id": "smoke",
-    "text": "Do you smoke?",
-    "type": "yesno"
-  },
-  {
-    "id": "cigs_per_day",
-    "text": "How many cigarettes per day?",
-    "type": "number",
-    "show_if": { "id": "smoke", "value": "yes" }
-  },
-  {
-    "id": "diet",
-    "text": "How would you rate your diet?",
-    "type": "choice",
-    "options": ["Excellent", "Good", "Poor"]
-  },
-  {
-    "id": "exercise",
-    "text": "Do you exercise regularly?",
-    "type": "yesno"
-  },
-  {
-    "id": "exercise_minutes",
-    "text": "How many minutes per week do you exercise?",
-    "type": "number",
-    "show_if": { "id": "exercise", "value": "yes" }
-  }
+  {"id":"Q1","section":"Demographics","text":"What is your date of birth (or age)?","input_type":"date_or_number","required":true,"help_text":"Age helps us select appropriate targets and screening prompts.","maps_to":"demographics.age","feeds_rules":["DM-001","DM-009"]},
+  {"id":"Q2","section":"Demographics","text":"What is your sex at birth?","input_type":"single_choice","required":true,"options":["male","female","prefer_not_say"],"maps_to":"demographics.sex","feeds_rules":["MOD-005","MOD-006","MOV-006"]},
+  {"id":"Q3","section":"Demographics","text":"Which best describes your current hormonal stage (if applicable)?","input_type":"single_choice","show_if":"Q2 in ['male','female']","options":["none","menstruating","perimenopause","menopause","pregnant","postpartum","andropause","TRT"],"maps_to":"demographics.hormonal_stage","feeds_rules":["MOD-005","MOD-006","MOV-006"]},
+  {"id":"Q4","section":"Demographics","text":"What is your height?","input_type":"number_cm","required":true,"min":100,"max":250,"maps_to":"body.height_cm","feeds_rules":["DM-001","DM-002"]},
+  {"id":"Q5","section":"Demographics","text":"What is your current weight?","input_type":"number_kg","required":true,"min":30,"max":300,"maps_to":"body.weight_kg","feeds_rules":["DM-001"]},
+  {"id":"Q6","section":"Demographics","text":"What is your waist measurement (at the navel)?","input_type":"number_cm","required":false,"min":40,"max":200,"help_text":"Use a soft tape; exhale normally; measure at the level of the belly button.","maps_to":"body.waist_cm","feeds_rules":["DM-002"]},
+  {"id":"Q7","section":"Goals","text":"What are your top 2–3 health goals?","input_type":"multi_choice","required":true,"max_choices":3,"options":["fat_loss","muscle_gain","strength","endurance","energy","sleep","stress","longevity","mobility","pain_reduction","metabolic_health"],"maps_to":"goals","feeds_rules":["DM-006","DM-009","L1-001"]},
+  {"id":"Q8","section":"Goals","text":"Which goal do you want to focus on first?","input_type":"single_choice","required":true,"options_dynamic_from":"Q7","maps_to":"goals.primary_focus","feeds_rules":["DM-009"]},
+  {"id":"Q8B","section":"Goals","text":"In your own words, what would success look like in 12 weeks?","input_type":"text","required":false,"placeholder":"e.g., down 10 lb, sleep 7.5h, BP under 130/80","maps_to":"goals.success_statement"},
+  {"id":"Q9","section":"Activity","text":"On average, how many steps do you take per day?","input_type":"single_choice","required":true,"options":["<3000","3000-5000","5000-7500","7500-10000",">10000"],"maps_to":"activity.baseline_steps","feeds_rules":["DM-003","MOV-002"]},
+  {"id":"Q10","section":"Activity","text":"How much cardio do you get in a typical week?","input_type":"single_choice","required":true,"options":["none","<60 min","60-150 min","150-300 min",">300 min"],"maps_to":"activity.cv_minutes_week","feeds_rules":["DM-003","MOV-001"]},
+  {"id":"Q11","section":"Activity","text":"How often do you perform strength/resistance training?","input_type":"single_choice","required":true,"options":["never","1","2","3+"],"maps_to":"activity.resistance_days_week","feeds_rules":["MOV-003","MOV-006"]},
+  {"id":"Q12","section":"Activity","text":"Do you currently have any injuries or movement limitations?","input_type":"yes_no","required":false,"maps_to":"activity.limitations_flag"},
+  {"id":"Q12A","section":"Activity","text":"Briefly describe any injuries/limitations.","input_type":"text","required":false,"show_if":"Q12 == true","maps_to":"activity.limitations_notes"},
+  {"id":"Q13","section":"Sleep","text":"On average, how many hours of sleep do you get per night?","input_type":"number_hours","required":true,"min":3,"max":12,"maps_to":"sleep.avg_hours","feeds_rules":["DM-005","SLP-001","SLP-002"]},
+  {"id":"Q13B","section":"Sleep","text":"How regular is your sleep schedule?","input_type":"single_choice","required":false,"options":["very_regular","somewhat_regular","irregular"],"maps_to":"sleep.regularity"},
+  {"id":"Q14","section":"Sleep","text":"Do you work night or rotating shifts?","input_type":"yes_no","required":true,"maps_to":"sleep.shift_work","feeds_rules":["SLP-003"]},
+  {"id":"Q15","section":"Sleep","text":"Do you have trouble falling asleep or staying asleep 3+ nights/week?","input_type":"yes_no","required":true,"maps_to":"sleep.insomnia_flag","feeds_rules":["SLP-004"]},
+  {"id":"Q16","section":"Sleep","text":"Has anyone told you that you snore loudly or stop breathing during sleep?","input_type":"yes_no","required":true,"maps_to":"sleep.osa_risk","feeds_rules":["DM-007","MOD-012","SLP-005"]},
+  {"id":"Q16B","section":"Sleep","text":"How refreshed do you feel on waking?","input_type":"single_choice","required":false,"options":["refreshed","somewhat_refreshed","not_refreshed"],"maps_to":"sleep.refreshment"},
+  {"id":"Q18","section":"Nutrition","text":"Which best describes your eating pattern?","input_type":"single_choice","required":true,"options":["omnivore","mediterranean","vegetarian","vegan","gluten_free","lactose_free","keto","other"],"maps_to":"diet.pattern","feeds_rules":["NUT-004","NUT-009","MOD-011"]},
+  {"id":"Q18B","section":"Nutrition","text":"Where do you get most of your meals?","input_type":"single_choice","required":false,"options":["mostly_cook","mostly_eat_out","mix"],"maps_to":"diet.cooking_confidence"},
+  {"id":"Q19","section":"Nutrition","text":"How many meals (or large snacks) do you typically eat per day?","input_type":"number","required":false,"min":1,"max":8,"maps_to":"diet.meals_per_day"},
+  {"id":"Q20","section":"Nutrition","text":"How often do you drink alcohol?","input_type":"single_choice","required":false,"options":["never","1-2/week","3-7/week","8+/week"],"maps_to":"diet.alcohol_units_week","feeds_rules":["NUT-005"]},
+  {"id":"Q21","section":"Nutrition","text":"Do you have difficulty accessing affordable, healthy foods?","input_type":"yes_no","required":false,"maps_to":"diet.food_access","feeds_rules":["MOD-011"]},
+  {"id":"Q23","section":"Medical","text":"Have you ever been told you have any of the following?","input_type":"multi_choice","required":false,"options":["prediabetes","t2d","htn","dyslipidemia","obesity","pcos","ckd","asthma","copd","cad","stroke","nafld","gerd","ibs","celiac","hypothyroid","hyperthyroid","depression","anxiety","adhd","chronic_pain","osteoarthritis","osteopenia","osteoporosis","osa","none"],"maps_to":"health.diagnoses","feeds_rules":["MOD-001","MOD-002","MOD-003","MOD-004","MOD-007","MOD-008","MOD-009","MOD-010"]},
+  {"id":"Q24","section":"Medical","text":"Do you know your average blood pressure? (systolic/diastolic)","input_type":"number_pair","required":false,"show_if":"Q23 includes 'htn'","maps_to":["vitals.home_bp_sbp","vitals.home_bp_dbp"],"feeds_rules":["DM-004","MOD-001"]},
+  {"id":"Q24B","section":"Medical","text":"Do you track your resting heart rate? If yes, what is it typically?","input_type":"number","required":false,"min":35,"max":140,"maps_to":"vitals.resting_hr"},
+  {"id":"Q26","section":"Medical","text":"Do you have recent lab results you want to enter?","input_type":"yes_no","required":false,"maps_to":"labs.has_labs"},
+  {"id":"Q26A","section":"Medical","text":"Hemoglobin A1c (%)","input_type":"number","required":false,"min":4.0,"max":15.0,"show_if":"Q26 == true","maps_to":"labs.a1c"},
+  {"id":"Q26B","section":"Medical","text":"Fasting glucose (mg/dL)","input_type":"number","required":false,"min":60,"max":300,"show_if":"Q26 == true","maps_to":"labs.fasting_glucose"},
+  {"id":"Q26C","section":"Medical","text":"LDL cholesterol (mg/dL)","input_type":"number","required":false,"min":30,"max":300,"show_if":"Q26 == true","maps_to":"labs.ldl"},
+  {"id":"Q26D","section":"Medical","text":"Triglycerides (mg/dL)","input_type":"number","required":false,"min":20,"max":1000,"show_if":"Q26 == true","maps_to":"labs.tg"},
+  {"id":"Q26E","section":"Medical","text":"eGFR (mL/min/1.73m²)","input_type":"number","required":false,"min":5,"max":200,"show_if":"Q26 == true","maps_to":"labs.egfr"},
+  {"id":"Q27","section":"Mental Health","text":"Over the last 2 weeks, how often have you had little interest or pleasure in doing things?","input_type":"phq2_scale","required":false,"maps_to":"screening.phq2","feeds_rules":["DM-007","MEN-002"]},
+  {"id":"Q29","section":"Mental Health","text":"Over the last 2 weeks, how often have you felt nervous, anxious, or on edge?","input_type":"gad2_scale","required":false,"maps_to":"screening.gad2","feeds_rules":["DM-007","MEN-002"]},
+  {"id":"Q29B","section":"Mental Health","text":"How stressed do you feel most days?","input_type":"scale_0_10","required":false,"maps_to":"screening.stress_0_10"},
+  {"id":"Q30","section":"Environment","text":"What best describes your work pattern?","input_type":"single_choice","required":false,"options":["standard","shift","rotating","gig","student","caregiving"],"maps_to":"environment.work_pattern"},
+  {"id":"Q31","section":"Barriers","text":"What are your biggest barriers to improving your health? (pick up to 3)","input_type":"multi_choice","required":false,"max_choices":3,"options":["time","stress","pain","motivation","budget","food_access","equipment","knowledge","other"],"maps_to":"readiness.barriers","feeds_rules":["ENV-003","L2-002"]},
+  {"id":"Q32","section":"Barriers","text":"How confident are you in your ability to make changes right now?","input_type":"scale_0_10","required":false,"maps_to":"readiness.confidence_0_10","feeds_rules":["L2-002"]},
+  {"id":"Q33","section":"Environment","text":"How often do you travel for work or life?","input_type":"single_choice","required":false,"options":["never","monthly","weekly"],"maps_to":"environment.travel_frequency"},
+  {"id":"Q34","section":"Supplements","text":"Do you currently take any supplements regularly?","input_type":"yes_no","required":false,"maps_to":"diet.supplements_flag"},
+  {"id":"Q34A","section":"Supplements","text":"List any supplements you take (optional).","input_type":"text","required":false,"show_if":"Q34 == true","maps_to":"diet.supplements_list"},
+  {"id":"Q35","section":"Safety","text":"Has a clinician ever told you to avoid exercise or only exercise under supervision?","input_type":"yes_no","required":false,"maps_to":"screening.par_q_plus_flag"},
+  {"id":"Q36","section":"Safety","text":"Do you get chest pain, severe shortness of breath, or dizziness with exercise?","input_type":"yes_no","required":false,"maps_to":"screening.exercise_risk_flag"}
 ]


### PR DESCRIPTION
## Summary
- expand rules.json with comprehensive health questionnaire
- add multi-step questionnaire wizard UI with autosave and conditional logic
- highlight selected buttons and validate required fields
- create simple report page and routing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ad5346fcc832e8e23c0173b84877d